### PR TITLE
Removes user stats from sidebar as they are included in the header

### DIFF
--- a/src/view/sidebar.js
+++ b/src/view/sidebar.js
@@ -7,28 +7,6 @@ function Sidebar (props) {
     var profile = _.find(props.profiles, { username: props.username })
 
     return html`<div class="feed-sidebar">
-        ${profile ?
-            html`<dl class="counts">
-                <div>
-                    <dd>${profile.following}</dd>
-                    <dt class="following">following</dt>
-                </div>
-                <div>
-                    <dd>${profile.followers}</dd>
-                    <dt class="followers">
-                        ${profile.followers === 1 ?  'follower' : 'followers'}
-                    </dt>
-                </div>
-                <div>
-                    <dd>${profile.posts}</dd>
-                    <dt class="posts-count">
-                        ${profile.posts === 1 ? 'post' : 'posts'}
-                    </dt>
-                </div>
-            </dl>` :
-            null
-        }
-
         <div class="join-today">
             <h3>Join Planetary today!</h3>
             <p>


### PR DESCRIPTION
This removes the user stats block from the sidebar, since it's already displayed in the header.

This is how it currently looks:
![Screen Shot 2022-01-18 at 17 47 02](https://user-images.githubusercontent.com/477835/149981214-09197742-bb76-46c1-8fdf-b6108a4bfb80.png)

And this is how it looks after removal:
![Screen Shot 2022-01-18 at 17 47 09](https://user-images.githubusercontent.com/477835/149981271-b46eaa45-4e56-4718-8501-60cd7500c44b.png)

