### PR TITLE
Improves markdown rendering, styles and readability

### DIFF
--- a/src/style/_feed-sidebar.scss
+++ b/src/style/_feed-sidebar.scss
@@ -1,7 +1,7 @@
 @use './variables' as v;
 
 .feed-sidebar {
-    // max-width: 300px;
+    max-width: 300px;
     @extend %block;
     filter: drop-shadow(0px 10px 30px rgba(0, 0, 0, 0.15));
 

--- a/src/style/_feed.scss
+++ b/src/style/_feed.scss
@@ -259,32 +259,5 @@ ul.feed {
         }
 
         .replies-stack_link {display: none;}
-
-        .markup {
-            align-self: stretch;
-            padding: 1.5rem;
-            overflow: hidden;
-
-            p {
-                margin: 0;
-                text-align: left;
-
-                img {
-                    border-radius: 0.6rem;
-                    width: 100%;
-                    display: block;
-                    box-shadow: 0px 10px 20px rgb(0 0 0 / 5%);
-                }
-
-                a {
-                    text-decoration: none;
-                    color: #D64082;
-
-                    &:hover {
-                        text-decoration: underline;
-                    }
-                }
-            }
-        }
     }
 }

--- a/src/style/_markdown.scss
+++ b/src/style/_markdown.scss
@@ -1,0 +1,85 @@
+.markup {
+    align-self: stretch;
+    padding: 1.5rem;
+    overflow: hidden;
+
+    h1, h2, h3, h4, h5, h6 {
+        font-family: sans-serif;
+        font-weight: 400;
+    }
+
+    h1 {font-size: 1.7rem;}
+
+    h2 {font-size: 1.5rem;}
+
+    h3 {font-size: 1.3rem;}
+
+    h4 {font-size: 1.2rem;}
+
+    p {
+        line-height: 1.4rem;
+        margin: 0;
+        text-align: left;
+        color: #c0bdc5;
+
+        img {
+            margin: 1.5rem 0;
+            border-radius: 0.6rem;
+            width: 100%;
+            display: block;
+        }
+
+        a {
+            text-decoration: none;
+            color: #D64082;
+
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+    }
+
+    pre {
+        background-color: #221B2E;
+        padding: 1.5rem;
+        margin: 1.5rem 0;
+        word-break: break-word; 
+        border-radius: 0.3rem;
+        white-space: pre-wrap;
+
+        code {
+            color: #8e7eaf;
+            line-height: 1.4rem;
+        }
+    }
+
+    ol, ul {
+        padding-left: 1.5rem;
+        margin: 1rem 0;
+
+        li {
+            margin: 1rem 0;
+            color: #c0bdc5;
+
+            strong {color: white;}
+        }
+    }
+
+    blockquote {
+        margin: 0;
+        padding: 3.5rem 1.5rem 1.5rem;
+        border-radius: 0.3rem;
+        background-color: #b59ae121;
+        position: relative;
+
+        &::before {
+            content: '“';
+            color: #D64082;
+            font-family: serif;
+            font-size: 3rem;
+            position: absolute;
+            top: 1rem;
+            left: 1.5rem;
+        }
+    }
+}

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -1,9 +1,10 @@
 @use './variables' as v;
 @use './layout';
 @use './feed';
+@use './_markdown';
 @use './feed-header';
 @use './feed-sidebar';
-@use './_responsive';
+@use './responsive';
 @use './home';
 
 html {


### PR DESCRIPTION
This adds a separate stylesheet containing correct styling for markdown content in posts.

Styled elements:

- blockquotes
- headings
- preformatted code blocks
- nested lists
- images

Here's a preview:

![screencapture-192-168-50-35-9966-feed-alice-2022-01-19-15_41_52-edit](https://user-images.githubusercontent.com/477835/150153593-fd950e6d-5722-4df0-913b-1d44f86005a6.png)

